### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,6 +1,6 @@
 function init --on-event init_fasd
   # Detect fasd
-  if not available fasd
+  if not type -q fasd
     echo "🍒  Please install 'fasd' first!"
     return
   end


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
