### PR TITLE
Separate args to `fasd --proc`.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -2,7 +2,7 @@
 if type -q fasd
   # Hook into fish preexec event
   function __fasd_run -e fish_preexec
-    command fasd --proc (command fasd --sanitize "$argv") > "/dev/null" 2>&1 &
+    command fasd --proc (command fasd --sanitize "$argv" | tr -s ' ' \n) > "/dev/null" 2>&1 &
   end
 else
   echo "🍒  Please install 'fasd' first!"


### PR DESCRIPTION
Briefly: right now, `fasd` isn't tracking files.
### Why?

"fasd --proc expects arguments to be passed in separately, but subshells in fish are implicitly quoted". 
### Solution (not perfect)

We can solve this for most cases by splitting on spaces. 

Discussed [here](https://github.com/fish-shell/fish-shell/issues/1358#issuecomment-74462654); solution down [here](https://github.com/fish-shell/fish-shell/issues/1358#issuecomment-76447368).
