### PR TITLE
Replace subprocess with read in fasd_cd

### DIFF
--- a/functions/fasd_cd.fish
+++ b/functions/fasd_cd.fish
@@ -3,7 +3,7 @@ function fasd_cd -d 'Function to execute built-in cd'
   if test (count $argv) -le 1
     command fasd "$argv"
   else
-	command fasd -e 'printf %s' $argv | read -l ret
+    command fasd -e 'printf %s' $argv | read -l ret
     test -z "$ret";
       and return
     test -d "$ret";

--- a/functions/fasd_cd.fish
+++ b/functions/fasd_cd.fish
@@ -3,7 +3,7 @@ function fasd_cd -d 'Function to execute built-in cd'
   if test (count $argv) -le 1
     command fasd "$argv"
   else
-    set -l ret (command fasd -e 'printf %s' $argv)
+	command fasd -e 'printf %s' $argv | read -l ret
     test -z "$ret";
       and return
     test -d "$ret";


### PR DESCRIPTION
Fish is unable to handle a subprocess that reads from stdin. The command 'read' allows a way around this. This restores the expected behavior of fasd_cd within fish.

Resolves Issue #8 