### PR TITLE
Suppress install message on non-interactive shell

### DIFF
--- a/conf.d/fasd.fish
+++ b/conf.d/fasd.fish
@@ -8,6 +8,6 @@ if type -q fasd
       command fasd --proc (command fasd --sanitize "$argv" | tr -s ' ' \n) > "/dev/null" 2>&1 &
     end
   end
-else
+else if status is-interactive
   echo "🍒  Please install 'fasd' first!"
 end


### PR DESCRIPTION
Non-interactive shells that produce output can break sftp and ssh
connections that run single commands.  Possibly related to #14.